### PR TITLE
Validate remote version files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # This file contains all notable changes to the AVC-VersionFileValidator
 
 ## master (not included in any release yet)
+* Validate remote version file if specified with `URL` property.
 
 
 ## v1

--- a/action.yml
+++ b/action.yml
@@ -3,7 +3,7 @@ description: 'Validate the KSP-AVC .version file of your mod against the AVC sch
 author: 'DasSkelett'
 inputs:
   exclude:
-    description: 'Comma-separated list of paths to version files to exclude as string, e.g. "KSP-AVC.version,GameData/DogeCoinFlag/DGC.version"'
+    description: 'JSON-array-like list of paths to version files to exclude (supports wildcards), e.g. ["KSP-AVC.version", "GameData/DogeCoinFlag/*.version"]'
     required: false
     default: ''
 runs:

--- a/tests/main.py
+++ b/tests/main.py
@@ -75,4 +75,25 @@ class TestStrangeNames(TestCase):
         self.assertEqual(status, 1)
         self.assertSetEqual(successful, {Path('CAPS.VERSION')})
         self.assertSetEqual(failed, {Path('camelCaseVersionMissing.Version')})
+        # Make sure 'not-detected.version.json' has not been detected.
         self.assertSetEqual(ignored, set())
+
+
+class TestSingleFiles(TestCase):
+    old_cwd = os.getcwd()
+
+    @classmethod
+    def setUpClass(cls):
+        os.chdir('./tests/workspaces/single-files')
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.old_cwd)
+
+    def test_invalidRemote(self):
+        (status, successful, failed, ignored) = validator.validate('')
+        self.assertIn(Path('invalid-remote.version'), failed)
+
+    def test_validRemote(self):
+        (status, successful, failed, ignored) = validator.validate('')
+        self.assertIn(Path('valid-remote.version'), successful)

--- a/tests/workspaces/default/default.version
+++ b/tests/workspaces/default/default.version
@@ -1,6 +1,5 @@
 {
   "NAME": "KSP-AVC Version File Validator",
-  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",

--- a/tests/workspaces/default/failing/failing-validation.version
+++ b/tests/workspaces/default/failing/failing-validation.version
@@ -1,6 +1,5 @@
 {
   "NAME": "KSP-AVC Version File Validator",
-  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",

--- a/tests/workspaces/default/recursiveness/recursive.version
+++ b/tests/workspaces/default/recursiveness/recursive.version
@@ -1,6 +1,5 @@
 {
   "NAME": "KSP-AVC Version File Validator",
-  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",

--- a/tests/workspaces/default/recursiveness/recursiveness2/recursive2.version
+++ b/tests/workspaces/default/recursiveness/recursiveness2/recursive2.version
@@ -1,6 +1,5 @@
 {
   "NAME": "KSP-AVC Version File Validator",
-  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",

--- a/tests/workspaces/single-files/invalid-remote.version
+++ b/tests/workspaces/single-files/invalid-remote.version
@@ -1,14 +1,16 @@
 {
   "NAME": "KSP-AVC Version File Validator",
+  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",
     "REPOSITORY": "AVC-VersionFileValidator"
   },
   "VERSION": {
-    "MAJOR": 1,
-    "MINOR": 1,
-    "PATCH": 1
+    "MAJOR": 0,
+    "MINOR": 0,
+    "PATCH": 0,
+    "BUILD": 1
   },
   "KSP_VERSION": "any"
 }

--- a/tests/workspaces/single-files/valid-remote.version
+++ b/tests/workspaces/single-files/valid-remote.version
@@ -1,14 +1,16 @@
 {
   "NAME": "KSP-AVC Version File Validator",
+  "URL": "https://raw.githubusercontent.com/DasSkelett/AVC-VersionFileValidator/master/tests/workspaces/single-files/valid-remote.version",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",
     "REPOSITORY": "AVC-VersionFileValidator"
   },
   "VERSION": {
-    "MAJOR": 1,
-    "MINOR": 1,
-    "PATCH": 1
+    "MAJOR": 0,
+    "MINOR": 0,
+    "PATCH": 0,
+    "BUILD": 1
   },
   "KSP_VERSION": "any"
 }

--- a/tests/workspaces/strange-names/camelCaseVersionMissing.Version
+++ b/tests/workspaces/strange-names/camelCaseVersionMissing.Version
@@ -1,6 +1,5 @@
 {
   "NAME": "KSP-AVC Version File Validator",
-  "URL": "https://github.com/DasSkelett/AVC-VersionFileValidator",
   "DOWNLOAD": "https://github.com/DasSkelett/AVC-VersionFileValidator/releases",
   "GITHUB": {
     "USERNAME": "DasSkelett",

--- a/validator/main.py
+++ b/validator/main.py
@@ -96,6 +96,25 @@ def check_single_file(f: Path, schema):
     print(f'Validating {f}')
     jsonschema.validate(json_file, schema)
 
+    # Check URL property ("Location of a remote version file for update checking")
+    vf_url = json_file.get('URL')
+    if vf_url:
+        try:
+            remote = json.loads(requests.get(vf_url).content)
+            jsonschema.validate(remote, schema)
+        except requests.exceptions.RequestException as e:
+            print(f'Failed downloading remote version file at {vf_url}. Note that the URL property, when used, \n'
+                  'must point to the "Location of a remote version file for update checking":')
+            raise e
+        except json.decoder.JSONDecodeError as e:
+            print(f'Failed loading remote version file at {vf_url}. Note that the URL property, when used, \n'
+                  'must point to the "Location of a remote version file for update checking":')
+            raise e
+        except jsonschema.ValidationError as e:
+            print(f'Validation failed for remote version file at {vf_url}. Note that the URL property, when used, \n'
+                  'must point to the "Location of a remote version file for update checking":')
+            raise e
+
 
 if __name__ == "__main__":
     EXCLUDE = os.getenv('INPUT_EXCLUDE')


### PR DESCRIPTION
## Motivation
The schema contains the following:
```
 "URL": {
            "description": "Location of a remote version file for update checking",
            "type": "string",
            "format": "uri"
        },
```
So the URL property, when specified, should be a valid URI, pointing to a valid remote version file which can be downloaded.

## Changes
When the file contains a `URL`, try to download it, load it as json and validate it.
This check is explicitly _not_ recursive, as it's likely that the remote file will point to itself. Also I don't think AVC itself or CKAN are handling this recursively.
Two tests are added: One checks a file with invalid remote URL, one checks a file with valid remote URL.
The "valid" remote URL is not yet valid, because it needs this PR to be merged first. This will make the CI check fail.

Closes #2 