### PR TITLE
Packagify the validator; use logging instead of print()

### DIFF
--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -21,7 +21,7 @@ jobs:
         pip install -r requirements.txt
     - name: Run unit tests directly
       run: |
-        python -m unittest tests/main.py
+        python -m unittest tests
     - name: Run unit tests in Docker container
       run: |
         docker build --target tests -t avc-versionfilevalidator .

--- a/.idea/dictionaries/default.xml
+++ b/.idea/dictionaries/default.xml
@@ -1,0 +1,7 @@
+<component name="ProjectDictionaryState">
+  <dictionary name="default">
+    <words>
+      <w>recursiveness</w>
+    </words>
+  </dictionary>
+</component>

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,8 @@ ENTRYPOINT ["python3.8"]
 FROM base as tests
 COPY tests/ /tests/
 WORKDIR /
-CMD ["-m", "unittest", "tests/main.py"]
+CMD ["-m", "unittest", "tests"]
 
 
 FROM base as prod
-CMD ["/validator/main.py"]
+CMD ["/validator"]

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ wget https://raw.githubusercontent.com/linuxgurugamer/KSPAddonVersionChecker/mas
 pip3 install --user jsonschema
 python3 -m jsonschema -i YourMod.version KSP-AVC.schema.json
 ```
-Is you use an IDEs that supports custom JSON schemas, I strongly recommend using it.
+Is you use an IDEs that supports custom JSON schemas, I strongly recommend using this feature.
 
 ### Validate multiple .version files once on your PC
 If you want to check an entire local directory with potentially multiple version files, use this action as standard Python application:
@@ -59,7 +59,7 @@ cd AVC-VersionFileValidator
 pip3 install --user -r requirements.txt
 # It is important that your current working directory is the directory where the version files you want to test are located!  
 cd ../<YourMod>
-python3 ../AVC-VersionFileValidator/validator/main.py
+python3 ../AVC-VersionFileValidator/validator
 ```
 
 ## Development
@@ -89,7 +89,7 @@ docker build --target tests -t avc-versionfilevalidator . && docker run avc-vers
 #### Without Docker Container
 If you want to run the unit tests on your host, do the following.
 ```sh
-python3 -m unittest tests/main.py
+python3 -m unittest tests
 ```
 Note that the test framework assumes that your current working directory is this project's root.
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,7 @@
+from .default import *
+from .singlefiles import *
+from .strangenames import *
+
+from validator.utils import setup_logger
+
+setup_logger(True)

--- a/tests/default.py
+++ b/tests/default.py
@@ -2,7 +2,7 @@ import os
 from pathlib import Path
 from unittest import TestCase
 
-import validator.main as validator
+import validator.validator as validator
 
 
 class TestDefault(TestCase):
@@ -57,43 +57,3 @@ class TestDefault(TestCase):
                                          Path('recursiveness/recursiveness2/recursive2.version')})
         self.assertSetEqual(ignored, {Path('default.version'), Path('failing/failing-validation.version')})
         self.assertEqual(failed, set())
-
-
-class TestStrangeNames(TestCase):
-    old_cwd = os.getcwd()
-
-    @classmethod
-    def setUpClass(cls):
-        os.chdir('./tests/workspaces/strange-names')
-
-    @classmethod
-    def tearDownClass(cls):
-        os.chdir(cls.old_cwd)
-
-    def test_findsAll(self):
-        (status, successful, failed, ignored) = validator.validate('')
-        self.assertEqual(status, 1)
-        self.assertSetEqual(successful, {Path('CAPS.VERSION')})
-        self.assertSetEqual(failed, {Path('camelCaseVersionMissing.Version')})
-        # Make sure 'not-detected.version.json' has not been detected.
-        self.assertSetEqual(ignored, set())
-
-
-class TestSingleFiles(TestCase):
-    old_cwd = os.getcwd()
-
-    @classmethod
-    def setUpClass(cls):
-        os.chdir('./tests/workspaces/single-files')
-
-    @classmethod
-    def tearDownClass(cls):
-        os.chdir(cls.old_cwd)
-
-    def test_invalidRemote(self):
-        (status, successful, failed, ignored) = validator.validate('')
-        self.assertIn(Path('invalid-remote.version'), failed)
-
-    def test_validRemote(self):
-        (status, successful, failed, ignored) = validator.validate('')
-        self.assertIn(Path('valid-remote.version'), successful)

--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from unittest import TestCase
+
+import validator.validator as validator
+
+
+class TestSingleFiles(TestCase):
+    old_cwd = os.getcwd()
+
+    @classmethod
+    def setUpClass(cls):
+        os.chdir('./tests/workspaces/single-files')
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.old_cwd)
+
+    def test_invalidRemote(self):
+        (status, successful, failed, ignored) = validator.validate('')
+        self.assertIn(Path('invalid-remote.version'), failed)
+
+    def test_validRemote(self):
+        (status, successful, failed, ignored) = validator.validate('')
+        self.assertIn(Path('valid-remote.version'), successful)

--- a/tests/strangenames.py
+++ b/tests/strangenames.py
@@ -1,0 +1,25 @@
+import os
+from pathlib import Path
+from unittest import TestCase
+
+import validator.validator as validator
+
+
+class TestStrangeNames(TestCase):
+    old_cwd = os.getcwd()
+
+    @classmethod
+    def setUpClass(cls):
+        os.chdir('./tests/workspaces/strange-names')
+
+    @classmethod
+    def tearDownClass(cls):
+        os.chdir(cls.old_cwd)
+
+    def test_findsAll(self):
+        (status, successful, failed, ignored) = validator.validate('')
+        self.assertEqual(status, 1)
+        self.assertSetEqual(successful, {Path('CAPS.VERSION')})
+        self.assertSetEqual(failed, {Path('camelCaseVersionMissing.Version')})
+        # Make sure 'not-detected.version.json' has not been detected.
+        self.assertSetEqual(ignored, set())

--- a/validator/__main__.py
+++ b/validator/__main__.py
@@ -1,0 +1,20 @@
+import os
+from distutils.util import strtobool
+
+from validator import validate
+from utils import setup_logger
+
+
+def validate_current_repository():
+    debug = bool(strtobool(os.getenv('INPUT_DEBUG', 'false')))
+    setup_logger(debug)
+
+    exclude = os.getenv('INPUT_EXCLUDE', '')
+
+    (status, successful, failed, ignored) = validate(exclude)
+    print(f'Exiting with status {status}, {len(successful)} successful, {len(failed)} failed, {len(ignored)} ignored.')
+    exit(status)
+
+
+if __name__ == "__main__":
+    validate_current_repository()

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -1,0 +1,51 @@
+import logging
+import sys
+
+
+def setup_logger(debug):
+    log = logging.getLogger('')
+    level = logging.DEBUG if debug else logging.INFO
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(LogFormatter())
+    log.addHandler(handler)
+    log.setLevel(level)
+    log.info(f'Logging started with level {level}')
+
+
+# https://stackoverflow.com/a/14859558
+class LogFormatter(logging.Formatter):
+
+    dbg_fmt = "::DEBUG::%(msg)s"
+    info_fmt = "::INFO::%(msg)s"
+    wrn_fmt = "::WARNING::%(msg)s"
+    err_fmt = "::ERROR::%(msg)s"
+
+    def __init__(self):
+        super().__init__(fmt="%(levelno)d: %(msg)s", datefmt=None, style='%')
+
+    def format(self, record):
+
+        # Save the original format configured by the user
+        # when the logger formatter was instantiated
+        format_orig = self._style._fmt
+
+        # Replace the original format with one customized by logging level
+        if record.levelno == logging.DEBUG:
+            self._style._fmt = LogFormatter.dbg_fmt
+
+        elif record.levelno == logging.INFO:
+            self._style._fmt = LogFormatter.info_fmt
+
+        elif record.levelno == logging.WARNING:
+            self._style._fmt = LogFormatter.wrn_fmt
+
+        elif record.levelno == logging.ERROR:
+            self._style._fmt = LogFormatter.err_fmt
+
+        # Call the original formatter class to do the grunt work
+        result = logging.Formatter.format(self, record)
+
+        # Restore the original format configured by the user
+        self._style._fmt = format_orig
+
+        return result

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -38,13 +38,11 @@ def validate(exclude) -> (int, Set[Path], Set[Path], Set[Path]):
             # The actual validation happens here.
             check_single_file(f, schema)
         except json.decoder.JSONDecodeError as e:
-            log.error(f'Failed loading {str(f)} as JSON. Check for syntax errors around the mentioned line:')
-            log.error(e)
+            log.error(f'Failed loading {str(f)} as JSON. Check for syntax errors around the mentioned line: {e}')
             failed_files.add(f)
             continue
         except jsonschema.ValidationError as e:
-            log.error(f'Validation of {f} failed:')
-            log.error(e)
+            log.error(f'Validation of {f} failed: {e}')
             failed_files.add(f)
             continue
 
@@ -52,8 +50,7 @@ def validate(exclude) -> (int, Set[Path], Set[Path], Set[Path]):
 
     log.debug('Done!')
     if failed_files:
-        log.error('The following files failed validation:')
-        log.error([str(f) for f in failed_files])
+        log.error(f'The following files failed validation: {[str(f) for f in failed_files]}')
         return 1, successful_files, failed_files, ignored_files
     else:
         return 0, successful_files, failed_files, ignored_files


### PR DESCRIPTION
## Changes
This PR modularizes the validator and allows it to be imported as a package.

It also introduces proper logging using Python's logging module.
I also implemented a custom logging formatter which prepends `::<log-level>::` to all messages. This allows the log messages to be interpreted as the right level by GitHub's action system. For example, warn messages will pop up in a window on the lower right when viewing the log of a workflow run.

![grafik](https://user-images.githubusercontent.com/28812678/72760592-9dd2c780-3bd9-11ea-8167-ea257762ff69.png)
