### PR TITLE
Add version comparison logic; Warn for outdated compatibility

### DIFF
--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -1,0 +1,27 @@
+name: Test full integration
+on:
+  push:
+  pull_request:
+    types: [opened, synchronize, reopened]
+
+jobs:
+  full_integration_run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set up Python 3.8
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+      - name: Install dependencies
+        run: |
+          pip3 install -r requirements.txt
+      - name: Run validator
+        run: |
+          export INPUT_EXCLUDE='["./failing/*"]'
+          cd tests/workspaces/default
+          python3 ../../../main.py
+

--- a/.idea/AVC-VersionFileValidator.iml
+++ b/.idea/AVC-VersionFileValidator.iml
@@ -1,8 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <module type="PYTHON_MODULE" version="4">
   <component name="NewModuleRootManager">
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/validator" isTestSource="false" />
+      <excludeFolder url="file://$MODULE_DIR$/venv" />
+    </content>
     <orderEntry type="jdk" jdkName="Python 3.8 (AVC-VersionFileValidator)" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+  <component name="TemplatesService">
+    <option name="TEMPLATE_FOLDERS">
+      <list>
+        <option value="$MODULE_DIR$/examples" />
+      </list>
+    </option>
   </component>
 </module>

--- a/.idea/dictionaries/default.xml
+++ b/.idea/dictionaries/default.xml
@@ -1,6 +1,8 @@
 <component name="ProjectDictionaryState">
   <dictionary name="default">
     <words>
+      <w>kerbal</w>
+      <w>kerbalstuff</w>
       <w>recursiveness</w>
     </words>
   </dictionary>

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,5 @@ CMD ["-m", "unittest", "tests"]
 
 
 FROM base as prod
-CMD ["/validator"]
+COPY main.py /main.py
+CMD ["/main.py"]

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # KSP-AVC Version File Validator
 
-This repository hosts a Docker-based GitHub Action written in Python3 that you can use in a workflow in your [KSP](https://www.kerbalspaceprogram.com/) mod repo.
+This repository hosts a Docker-based GitHub Action written in Python3.8 that you can use in a workflow in your [KSP](https://www.kerbalspaceprogram.com/) mod repo.
 It will validate all [KSP-AVC](https://github.com/linuxgurugamer/KSPAddonVersionChecker) version files in the repository against [the official KSP-AVC schema](https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/master/KSP-AVC.schema.json).
 
 This is intended for authors and maintainers of [Kerbal Space Program](https://www.kerbalspaceprogram.com/) mods.

--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 import os
 from distutils.util import strtobool
 
-from validator import validate
-from utils import setup_logger
+from validator.utils import setup_logger
+from validator.validator import validate_cwd
 
 
 def validate_current_repository():
@@ -11,7 +11,7 @@ def validate_current_repository():
 
     exclude = os.getenv('INPUT_EXCLUDE', '')
 
-    (status, successful, failed, ignored) = validate(exclude)
+    (status, successful, failed, ignored) = validate_cwd(exclude)
     print(f'Exiting with status {status}, {len(successful)} successful, {len(failed)} failed, {len(ignored)} ignored.')
     exit(status)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,7 +1,7 @@
+from validator.utils import setup_logger
 from .default import *
+from .ksp_version import *
 from .singlefiles import *
 from .strangenames import *
-
-from validator.utils import setup_logger
 
 setup_logger(True)

--- a/tests/default.py
+++ b/tests/default.py
@@ -17,15 +17,15 @@ class TestDefault(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_doubleQuotation(self):
-        (status, successful, failed, ignored) = validator.validate('"failing/failing-validation.version"')
+        (status, successful, failed, ignored) = validator.validate_cwd('"failing/failing-validation.version"')
         self.assertEqual(status, 0)
 
     def test_invalidWorkspace_recursive(self):
-        (status, successful, failed, ignored) = validator.validate('')
+        (status, successful, failed, ignored) = validator.validate_cwd('')
         self.assertEqual(status, 1)
 
     def test_exclusionWildcard(self):
-        (status, successful, failed, ignored) = validator.validate('failing/*.version')
+        (status, successful, failed, ignored) = validator.validate_cwd('failing/*.version')
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, {Path('default.version'), Path('recursiveness/recursive.version'),
                                          Path('recursiveness/recursiveness2/recursive2.version')})
@@ -33,7 +33,7 @@ class TestDefault(TestCase):
         self.assertEqual(failed, set())
 
     def test_excludeAll(self):
-        (status, successful, failed, ignored) = validator.validate('["./**/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./**/*"]')
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, set())
         self.assertSetEqual(ignored, {Path('default.version'),
@@ -43,7 +43,7 @@ class TestDefault(TestCase):
         self.assertEqual(failed, set())
 
     def test_recursiveExclusion(self):
-        (status, successful, failed, ignored) = validator.validate('["./recursiveness/**/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./recursiveness/**/*"]')
         self.assertEqual(status, 1)
         self.assertSetEqual(successful, {Path('default.version')})
         self.assertSetEqual(ignored, {Path('recursiveness/recursive.version'),
@@ -51,7 +51,7 @@ class TestDefault(TestCase):
         self.assertEqual(failed, {Path('failing/failing-validation.version')})
 
     def test_multipleExclusions(self):
-        (status, successful, failed, ignored) = validator.validate('["./*.version", "./failing/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./*.version", "./failing/*"]')
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, {Path('recursiveness/recursive.version'),
                                          Path('recursiveness/recursiveness2/recursive2.version')})

--- a/tests/ksp_version.py
+++ b/tests/ksp_version.py
@@ -1,0 +1,61 @@
+from unittest import TestCase
+
+from validator.ksp_version import KspVersion
+
+
+class TestKspVersion(TestCase):
+
+    def test_try_parse_valid_string(self):
+        v = KspVersion.try_parse('1.2.3.4')
+        self.assertIsNotNone(v)
+        self.assertEqual(v.major, 1)
+        self.assertEqual(v.minor, 2)
+        self.assertEqual(v.patch, 3)
+        self.assertEqual(v.build, 4)
+
+    def test_try_parse_valid_dict(self):
+        v = KspVersion.try_parse({
+            'MAJOR': '9', 'MINOR': '8',
+            'PATCH': '7', 'BUILD': '6'
+        })
+        self.assertIsNotNone(v)
+        self.assertEqual(v.major, 9)
+        self.assertEqual(v.minor, 8)
+        self.assertEqual(v.patch, 7)
+        self.assertEqual(v.build, 6)
+
+    def test_try_parse_invalid(self):
+        v = KspVersion.try_parse('xxx.yyy.zzz')
+        self.assertIsNone(v)
+
+    def test_comp_different_level(self):
+        v1 = KspVersion('1.2.3')
+        v2 = KspVersion('1.2')
+
+        self.assertEqual(v1, v2)
+        self.assertFalse(v1 < v2)
+        self.assertFalse(v1 > v2)
+        self.assertFalse(v2 < v1)
+        self.assertFalse(v2 > v1)
+
+    def test_is_contained_in_true(self):
+        v_latest_ksp = KspVersion('1.8.1')
+        v_ksp = KspVersion('1.8')
+        v_ksp_min = KspVersion('1.7')
+        v_ksp_max = KspVersion('1.8.9')
+
+        self.assertTrue(v_latest_ksp.is_contained_in(v_ksp, None, None))
+        self.assertTrue(v_latest_ksp.is_contained_in(None, v_ksp_min, None))
+        self.assertTrue(v_latest_ksp.is_contained_in(None, None, v_ksp_max))
+        self.assertTrue(v_latest_ksp.is_contained_in(v_ksp, v_ksp_min, v_ksp_max))
+
+    def test_is_contained_in_newer_ksp(self):
+        v_latest_ksp = KspVersion('1.9.1')
+        v_ksp = KspVersion('1.8')
+        v_ksp_min = KspVersion('1.7')
+        v_ksp_max = KspVersion('1.8.9')
+
+        self.assertFalse(v_latest_ksp.is_contained_in(v_ksp, None, None))
+        self.assertTrue(v_latest_ksp.is_contained_in(None, v_ksp_min, None))
+        self.assertFalse(v_latest_ksp.is_contained_in(None, None, v_ksp_max))
+        self.assertFalse(v_latest_ksp.is_contained_in(v_ksp, v_ksp_min, v_ksp_max))

--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -17,9 +17,9 @@ class TestSingleFiles(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_invalidRemote(self):
-        (status, successful, failed, ignored) = validator.validate('')
+        (status, successful, failed, ignored) = validator.validate_cwd('')
         self.assertIn(Path('invalid-remote.version'), failed)
 
     def test_validRemote(self):
-        (status, successful, failed, ignored) = validator.validate('')
+        (status, successful, failed, ignored) = validator.validate_cwd('')
         self.assertIn(Path('valid-remote.version'), successful)

--- a/tests/strangenames.py
+++ b/tests/strangenames.py
@@ -17,7 +17,7 @@ class TestStrangeNames(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_findsAll(self):
-        (status, successful, failed, ignored) = validator.validate('')
+        (status, successful, failed, ignored) = validator.validate_cwd('')
         self.assertEqual(status, 1)
         self.assertSetEqual(successful, {Path('CAPS.VERSION')})
         self.assertSetEqual(failed, {Path('camelCaseVersionMissing.Version')})

--- a/validator/ksp_version.py
+++ b/validator/ksp_version.py
@@ -1,0 +1,97 @@
+import re
+from functools import total_ordering
+
+
+@total_ordering
+class KspVersion:
+    rgx = re.compile('^(?P<major>\d+)\.(?P<minor>\d+)(\.(?P<patch>\d+))?(\.(?P<build>\d+))?$')
+
+    @classmethod
+    def try_parse(cls, version):
+        try:
+            return KspVersion(version)
+        except:
+            return None
+
+    def __init__(self, version):
+        # Assume it's either 'any' or a semantic version according to the schema.
+        if isinstance(version, str):
+            if version == 'any':
+                self.any = True
+            else:
+                self.any = False
+                match = self.rgx.fullmatch(version)
+                self.major = int(match.group('major'))
+                self.minor = int(match.group('minor'))
+                self.patch = int(m) if (m := match.group('patch')) is not None else None
+                self.build = int(m) if (m := match.group('build')) is not None else None
+
+        elif isinstance(version, dict):
+            self.major = int(version.get('MAJOR'))
+            self.minor = int(version.get('MINOR'))
+            self.patch = int(m) if (m := version.get('PATCH')) is not None else None
+            self.build = int(m) if (m := version.get('BUILD')) is not None else None
+        else:
+            raise TypeError('The version is neither a well-formatted string nor a dict.')
+        if not (self.major and self.minor):
+            raise TypeError('Version needs at least a MAJOR and MINOR.')
+
+    # From AVC code:
+    # (Ignoring KSP_INCLUDE_VERSIONS and KSP_EXCLUDE_VERSIONS)
+    # If no ksp_version_min and no ksp_version_max are defined, return whether compatible with ksp_version
+    # If at least one of _min or _max is defined, return whether it matches those two.
+    # That means, ksp_version is ignored when _min and/or _max are defined.
+    # https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/90ca9738da412f31a95a29209784ad48e8d082c4/KSP-AVC/AddonInfo.cs#L149-L165
+    # This is neat, because CKAN handles that pretty similar.
+    def is_contained_in(self, ksp_version, ksp_version_min, ksp_version_max):
+        if self.any:
+            return True
+        if ksp_version_min and ksp_version_max:
+            return ksp_version_min <= self <= ksp_version_max
+        if ksp_version_min and not ksp_version_max:
+            return ksp_version_min <= self
+        if ksp_version_max and not ksp_version_min:
+            return self <= ksp_version_max
+        # Else no _min or _max
+        if ksp_version:
+            return self == ksp_version
+        return False
+
+    def __eq__(self, other):
+        return not self > other and not other > self
+
+    def __gt__(self, other):
+        # Thanks to the  regex we can assume everything is a int.
+        # We can also assume major and minor exist.
+        # One specialty: a.b is always equal to a.b.c and a.b.c.d
+        if self.major > other.major:
+            return True
+        elif self.major < other.major:
+            return False
+        if self.minor > other.minor:
+            return True
+        elif self.minor < other.minor:
+            return False
+        if self.patch and other.patch:
+            if self.patch > other.patch:
+                return True
+            elif self.patch < other.patch:
+                return False
+        else:
+            return False
+        if self.build and other.build:
+            if self.build > other.build:
+                return True
+            elif self.build < other.build:
+                return False
+            elif self.build == other.build:
+                return False
+        else:
+            return False
+
+    def __str__(self):
+        string = '' + str(self.major)
+        string = string + '.' + str(self.minor)
+        string = string + '.' + str(self.patch) if self.patch else string
+        string = string + '.' + str(self.build) if self.build else string
+        return string

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -8,8 +8,7 @@ import requests
 
 
 # Returns (status, successful, failed, ignored)
-def validate(exclude) -> (int, Set[Path], Set[Path], Set[Path]):
-
+def validate_cwd(exclude) -> (int, Set[Path], Set[Path], Set[Path]):
     all_exclusions = calculate_all_exclusions(exclude)
 
     # GH will set the cwd of the container to the so-called workspace, which is a clone of the triggering repo,

--- a/validator/versionfile.py
+++ b/validator/versionfile.py
@@ -1,0 +1,71 @@
+import json
+
+import jsonschema
+import requests
+
+from .ksp_version import KspVersion
+
+
+class VersionFile:
+
+    def __init__(self, content: str):
+
+        self.json = json.loads(content)
+        self.raw = content
+
+        self.name = self.json.get('NAME')
+        self.url = self.json.get('URL')
+        self.download = self.json.get('DOWNLOAD')
+        self.changelog = self.json.get('CHANGE_LOG')
+        self.changelog_url = self.json.get('CHANGE_LOG_URL')
+
+        if gh := self.json.get('GITHUB'):
+            self.github = True
+            self.github_username = gh.get('USERNAME')
+            self.github_repository = gh.get('REPOSITORY')
+            self.github_allow_prerelease = gh.get('ALLOW_PRE_RELEASE')
+
+        self.disallow_version_override = self.json.get('DISALLOW_VERSION_OVERRIDE')
+        self.kerbalstuff_url = self.json.get('KERBAL_STUFF_URL')
+        self.assembly_name = self.json.get('ASSEMBLY_NAME')
+        self.ksp_version_include = self.json.get('KSP_VERSION_INCLUDE')
+        self.ksp_version_include = self.json.get('KSP_VERSION_INCLUDE')
+        self.ksp_version_exclude = self.json.get('KSP_VERSION_EXCLUDE')
+        self.local_has_priority = self.json.get('LOCAL_HAS_PRIORITY')
+        self.remote_has_priority = self.json.get('REMOTE_HAS_PRIORITY')
+
+        self.version = self.json.get('VERSION')
+
+        self.ksp_version = KspVersion.try_parse(v) if (v := self.json.get('KSP_VERSION')) is not None else None
+        self.ksp_version_min = KspVersion.try_parse(v) if (v := self.json.get('KSP_VERSION_MIN')) is not None else None
+        self.ksp_version_max = KspVersion.try_parse(v) if (v := self.json.get('KSP_VERSION_MAX')) is not None else None
+
+        # I doubt we will ever have to handle with them, so I don't care about INSTALL_LOC* for now.
+
+        self._remote = None
+        self.valid = False
+
+    def get_remote(self):
+        if self._remote:
+            return self._remote
+        if not self.url:
+            return None
+        self._remote = VersionFile(requests.get(self.url).content)
+        return self._remote
+
+    # Validates this and optional a remote version file. Throws all exception it encounters.
+    def validate(self, schema, validate_remote=False):
+        self.valid = False
+        jsonschema.validate(self.json, schema)
+
+        if not validate_remote:
+            self.valid = True
+            return
+
+        remote = self.get_remote()
+        remote.validate(schema, False)
+        # No exceptions -> True
+        self.valid = True
+
+    def is_compatible_with_ksp(self, version: KspVersion):
+        return version.is_contained_in(self.ksp_version, self.ksp_version_min, self.ksp_version_max)


### PR DESCRIPTION
## Changes
* Add comparison logic for KSP versions. A bit special: `a.b` counts as equal to `a.b.c` and `a.b.c.d`.
For example: 1.2 == 1.2.6; 1.2 == 1.2.9.7; 1.2.6 != 1.2.9.7

* Use this logic in `KspVersion.is_contained_in(ksp_version, ksp_version_min, ksp_version_max)`: This method is used to check whether a given KSP version is in the range that the three arguments specifiy.
It follows the AVC logic (and CKAN is pretty much the same):
	* If at least one of `KSP_VERSION_MIN` or `KSP_VERSION_MAX` is specified, use those two to set the compatibility range.
	* If not, use `KSP_VERSION`.
	* `KSP_VERSION_INCLUDE` and `KSP_VERSION_EXCLUDE` are ignored for the time being.

* Pretty much the entire version file spec is now modelled in `versionfile.py`. Any additional property checks should be easy to incorporate in the future.

* I think I slowly understand how I should handle the package <-> script thing. `/validator/__main__.py` is now `/main.py`, out of the `validator` package. That means it can now import the package properly, and import statement inside the package stay relative.

Closes #1