### PR TITLE
Throw validation errors only once; format 'requests' debug logging

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python3.8
+
 import os
 from distutils.util import strtobool
 

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -45,6 +45,11 @@ class LogFormatter(logging.Formatter):
         # Call the original formatter class to do the grunt work
         result = logging.Formatter.format(self, record)
 
+        # If the log statements contains legacy formatted strings with %s / %d ...
+        # logging.Formatter.format() apparently tries to handle it, but doesn't somehow.
+        # Only encountered with requests.
+        result = result % record.args
+
         # Restore the original format configured by the user
         self._style._fmt = format_orig
 

--- a/validator/versionfile.py
+++ b/validator/versionfile.py
@@ -1,6 +1,7 @@
 import json
 
 import jsonschema
+import logging as log
 import requests
 
 from .ksp_version import KspVersion
@@ -50,6 +51,7 @@ class VersionFile:
             return self._remote
         if not self.url:
             return None
+        log.debug('Fetching remote...')
         self._remote = VersionFile(requests.get(self.url).content)
         return self._remote
 


### PR DESCRIPTION
## Problems
The validation exceptions are raised twice for remote files, resulting in two log entries. Once with a remote-specific message, and once with the normal message for non-remote version files (which includes the error message itself).
This can be confusing.

A `requests.exceptions.RequestException` caused an unhandled exception because it was re-raised without catching.

When debug logging is enabled, the log entries from the `requests` library are not formatted. `%s` or `%d` and so on were not replaced by the actual values. I thought `logging.Formatter.format(self, record)` would handle this, but it doesn't.

## Changes
Refactor `check_single_file()` to return a bool to indicate the result of the validation, instead of relying on error raising.
So all exceptions are catched in `check_single_file()` itself, and the corresponding log message is written, adjusted for remote or "standard" version files.

Execute `result = result % record.args` before returning `result` in `LogFormatter.format()`.