### PR TITLE
Convert to GitHub raw URIs before downloading remote files

### DIFF
--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/.idea/runConfigurations/Run__default_workspace_.xml
+++ b/.idea/runConfigurations/Run__default_workspace_.xml
@@ -1,0 +1,24 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Run (default workspace)" type="PythonConfigurationType" factoryName="Python">
+    <module name="AVC-VersionFileValidator" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$/tests/workspaces/default" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/main.py" />
+    <option name="PARAMETERS" value="" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Tests__Docker_.xml
+++ b/.idea/runConfigurations/Tests__Docker_.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Tests (Docker)" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
+    <deployment type="dockerfile">
+      <settings>
+        <option name="buildCliOptions" value="--target tests" />
+        <option name="command" value="" />
+        <option name="containerName" value="" />
+        <option name="entrypoint" value="" />
+        <option name="imageTag" value="" />
+        <option name="commandLineOptions" value="" />
+        <option name="sourceFilePath" value="Dockerfile" />
+      </settings>
+    </deployment>
+    <method v="2" />
+  </configuration>
+</component>

--- a/.idea/runConfigurations/Unittests.xml
+++ b/.idea/runConfigurations/Unittests.xml
@@ -1,0 +1,18 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="Unittests" type="tests" factoryName="Unittests">
+    <module name="AVC-VersionFileValidator" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <option name="SDK_HOME" value="$PROJECT_DIR$/venv/bin/python" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="false" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <option name="_new_pattern" value="&quot;&quot;" />
+    <option name="_new_additionalArguments" value="&quot;&quot;" />
+    <option name="_new_target" value="&quot;$PROJECT_DIR$/tests&quot;" />
+    <option name="_new_targetType" value="&quot;PATH&quot;" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 
 The MIT License (MIT)
 
-Copyright (c) 2018 GitHub, Inc. and contributors
+Copyright (c) 2020 DasSkelett and KSP-AVC Version File Validator contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,5 +3,8 @@ from .default import *
 from .ksp_version import *
 from .singlefiles import *
 from .strangenames import *
+from .versionfile import *
 
-setup_logger(True)
+setup_logger(True, 'tests')
+# Use logging.getLogger('tests').<lvl>() for logging in the tests.
+# This will format the messages so that GitHub can parse them as warnings or errors.

--- a/tests/versionfile.py
+++ b/tests/versionfile.py
@@ -1,0 +1,37 @@
+from unittest import TestCase
+
+from validator.versionfile import get_raw_uri
+
+
+class TestVersionFile(TestCase):
+
+    def test_getRawUri_blob(self):
+        before = 'https://github.com/DasSkelett/AVC-VersionFileValidator/blob/master/README.md'
+        expect_after = 'https://github.com/DasSkelett/AVC-VersionFileValidator/raw/master/README.md'
+
+        got_after = get_raw_uri(before)
+
+        self.assertEqual(expect_after, got_after)
+
+    def test_getRawUri_tree(self):
+        before = 'https://github.com/DasSkelett/AVC-VersionFileValidator/tree/master/README.md'
+        expect_after = 'https://github.com/DasSkelett/AVC-VersionFileValidator/raw/master/README.md'
+
+        got_after = get_raw_uri(before)
+
+        self.assertEqual(expect_after, got_after)
+
+    def test_getRawUri_doubleBlob(self):
+        before = 'https://github.com/DasSkelett/AVC-VersionFileValidator/blob/master/blob/README.md'
+        expect_after = 'https://github.com/DasSkelett/AVC-VersionFileValidator/raw/master/blob/README.md'
+
+        got_after = get_raw_uri(before)
+
+        self.assertEqual(expect_after, got_after)
+
+    def test_getRawUri_noGH(self):
+        before = 'https://no-github.com/DasSkelett/AVC-VersionFileValidator/tree/master/README.md'
+
+        got_after = get_raw_uri(before)
+
+        self.assertEqual(before, got_after)

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -2,14 +2,14 @@ import logging
 import sys
 
 
-def setup_logger(debug):
-    log = logging.getLogger('')
+def setup_logger(debug, logger_name=''):
+    log = logging.getLogger(logger_name)
     level = logging.DEBUG if debug else logging.INFO
     handler = logging.StreamHandler(sys.stdout)
     handler.setFormatter(LogFormatter())
     log.addHandler(handler)
     log.setLevel(level)
-    log.info(f'Logging started with level {level}')
+    log.info(f'Logger {logger_name} started with level {level}')
 
 
 # https://stackoverflow.com/a/14859558


### PR DESCRIPTION
## Problem
AVC and CKAN accept `blob/` and `tree/` URLs for remote version files and convert them before checking them.
AVC-VFV currently doesn't, it logs an error for the remote file because the downloaded file is not JSON, but HTML.

## Changes
### Raw URIs
Change the key (lack of better name...) of URLs with the host `github.com` and where the key of `/<User>/<Repo>/<key>/` is either `blob` or `tree` to `raw`.

This uses some regex magic, and is handled similar to CKAN, but different to AVC itself.
AVC will convert _every_ occurrence of `/tree/` or `/blob/` to a raw URI, so possibly breaking  the URIs if the version file is in a path with a folder named `tree` or `blob`.
https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/90ca9738da412f31a95a29209784ad48e8d082c4/KSP-AVC/AddonInfo.cs#L423-L434

### Logging
When running the tests, the log output from functions called in these tests is no longer formatted for GitHubs log mechanism. This should prevent displaying the block on the bottom right for warnings and errors which are expected.