### PR TITLE
Fix incorrect compatibility warning for `"KSP_VERSION": "any"`

### DIFF
--- a/tests/ksp_version.py
+++ b/tests/ksp_version.py
@@ -59,3 +59,18 @@ class TestKspVersion(TestCase):
         self.assertTrue(v_latest_ksp.is_contained_in(None, v_ksp_min, None))
         self.assertFalse(v_latest_ksp.is_contained_in(None, None, v_ksp_max))
         self.assertFalse(v_latest_ksp.is_contained_in(v_ksp, v_ksp_min, v_ksp_max))
+
+    def test_any_contains_all(self):
+        v_latest_ksp = KspVersion('1.8.1')
+        v_ksp = KspVersion('any')
+
+        self.assertTrue(v_latest_ksp.is_contained_in(v_ksp, None, None))
+
+    def test_any_contained_by_all(self):
+        # This shouldn't be encountered in the real world.
+        # The KSP version map from CKAN doesn't contain 'any'.
+        # But ss_contained_in() should still return True.
+        v_latest_ksp = KspVersion('any')
+        v_ksp = KspVersion('1.8.1')
+
+        self.assertTrue(v_latest_ksp.is_contained_in(v_ksp, None, None))

--- a/validator/ksp_version.py
+++ b/validator/ksp_version.py
@@ -18,6 +18,7 @@ class KspVersion:
         if isinstance(version, str):
             if version == 'any':
                 self.any = True
+                return
             else:
                 self.any = False
                 match = self.rgx.fullmatch(version)
@@ -44,7 +45,8 @@ class KspVersion:
     # https://github.com/linuxgurugamer/KSPAddonVersionChecker/blob/90ca9738da412f31a95a29209784ad48e8d082c4/KSP-AVC/AddonInfo.cs#L149-L165
     # This is neat, because CKAN handles that pretty similar.
     def is_contained_in(self, ksp_version, ksp_version_min, ksp_version_max):
-        if self.any:
+        if self.any or getattr(ksp_version, 'any', False) \
+                or getattr(ksp_version_min, 'any', False) or getattr(ksp_version_max, 'any', False):
             return True
         if ksp_version_min and ksp_version_max:
             return ksp_version_min <= self <= ksp_version_max


### PR DESCRIPTION
## Problem
When `KSP_VERSION`, `KSP_VERSION_MIN` or `KSP_VERSION_MAX` are set to `"any"`, the AVC-VFV incorrectly claims incompatibility.

## Changes
The version inclusion logic now returns `True` if one of the versions is set to `any`. This means every version is seen as included in `any`, and `any` is seen as included in each version.
Yes, this is a bit of an unintuitive behaviour, but it's needed for how the KSP compatibility is calculated.