### PR TITLE
Download schema + build map only once during tests

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,6 +5,6 @@ from .singlefiles import *
 from .strangenames import *
 from .versionfile import *
 
-setup_logger(True, 'tests')
 # Use logging.getLogger('tests').<lvl>() for logging in the tests.
 # This will format the messages so that GitHub can parse them as warnings or errors.
+setup_logger(True, 'tests')

--- a/tests/default.py
+++ b/tests/default.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import TestCase
 
 import validator.validator as validator
+from .test_utils import schema, build_map
 
 
 class TestDefault(TestCase):
@@ -17,15 +18,16 @@ class TestDefault(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_doubleQuotation(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('"failing/failing-validation.version"')
+        (status, successful, failed, ignored) = validator.validate_cwd(
+            '"failing/failing-validation.version"', schema, build_map)
         self.assertEqual(status, 0)
 
     def test_invalidWorkspace_recursive(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('')
+        (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
         self.assertEqual(status, 1)
 
     def test_exclusionWildcard(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('failing/*.version')
+        (status, successful, failed, ignored) = validator.validate_cwd('failing/*.version', schema, build_map)
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, {Path('default.version'), Path('recursiveness/recursive.version'),
                                          Path('recursiveness/recursiveness2/recursive2.version')})
@@ -33,7 +35,7 @@ class TestDefault(TestCase):
         self.assertEqual(failed, set())
 
     def test_excludeAll(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('["./**/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./**/*"]', schema, build_map)
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, set())
         self.assertSetEqual(ignored, {Path('default.version'),
@@ -43,7 +45,8 @@ class TestDefault(TestCase):
         self.assertEqual(failed, set())
 
     def test_recursiveExclusion(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('["./recursiveness/**/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./recursiveness/**/*"]',
+                                                                       schema, build_map)
         self.assertEqual(status, 1)
         self.assertSetEqual(successful, {Path('default.version')})
         self.assertSetEqual(ignored, {Path('recursiveness/recursive.version'),
@@ -51,7 +54,8 @@ class TestDefault(TestCase):
         self.assertEqual(failed, {Path('failing/failing-validation.version')})
 
     def test_multipleExclusions(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('["./*.version", "./failing/*"]')
+        (status, successful, failed, ignored) = validator.validate_cwd('["./*.version", "./failing/*"]',
+                                                                       schema, build_map)
         self.assertEqual(status, 0)
         self.assertSetEqual(successful, {Path('recursiveness/recursive.version'),
                                          Path('recursiveness/recursiveness2/recursive2.version')})

--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import TestCase
 
 import validator.validator as validator
+from .test_utils import schema, build_map
 
 
 class TestSingleFiles(TestCase):
@@ -17,9 +18,9 @@ class TestSingleFiles(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_invalidRemote(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('')
+        (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
         self.assertIn(Path('invalid-remote.version'), failed)
 
     def test_validRemote(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('')
+        (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
         self.assertIn(Path('valid-remote.version'), successful)

--- a/tests/strangenames.py
+++ b/tests/strangenames.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import TestCase
 
 import validator.validator as validator
+from .test_utils import schema, build_map
 
 
 class TestStrangeNames(TestCase):
@@ -17,7 +18,7 @@ class TestStrangeNames(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_findsAll(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('')
+        (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
         self.assertEqual(status, 1)
         self.assertSetEqual(successful, {Path('CAPS.VERSION')})
         self.assertSetEqual(failed, {Path('camelCaseVersionMissing.Version')})

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,5 @@
+from validator.validator import get_schema, get_build_map
+
+
+schema = get_schema()
+build_map = get_build_map()

--- a/validator/versionfile.py
+++ b/validator/versionfile.py
@@ -71,6 +71,8 @@ class VersionFile:
         self.valid = True
 
     def is_compatible_with_ksp(self, version: KspVersion) -> bool:
+        if version is None:
+            return False
         return version.is_contained_in(self.ksp_version, self.ksp_version_min, self.ksp_version_max)
 
 
@@ -81,7 +83,7 @@ def get_raw_uri(uri: str) -> str:
     if parts.netloc != 'github.com':
         return uri
 
-    # Do a bit of a dance. We con't want to replace 'tree' or 'blob' if it's part of a filename.
+    # Do a bit of a dance. We don't want to replace 'tree' or 'blob' if it's part of a filename.
     # AVC doesn't pay attention to this, it replaces all occurrences of those two keys wherever they are,
     # and potentially destroys URLs this way.
     path_regex = re.compile(


### PR DESCRIPTION
## Motivation
The tests currently download the schema + build map every time `validate_cwd()` is called. This slows down the tests substantially, and also generates unnecessary network traffic, with the potential to get rate limited by GitHub.


## Changes
`validate_cwd()` has now the optional arguments `schema` and `build_map`.
If they are set, it uses the supplied schema + build map instead of downloading them.
This is intended for usage in tests, the two arguments should be passed very carefully.