### PR TITLE
Don't fail whole validation for invalid remote files

### DIFF
--- a/main.py
+++ b/main.py
@@ -14,7 +14,7 @@ def validate_current_repository():
     exclude = os.getenv('INPUT_EXCLUDE', '')
 
     (status, successful, failed, ignored) = validate_cwd(exclude)
-    print(f'Exiting with status {status}, {len(successful)} successful, {len(failed)} failed, {len(ignored)} ignored.')
+    print(f'Exiting with status {status}: {len(successful)} successful, {len(failed)} failed, {len(ignored)} ignored.')
     exit(status)
 
 

--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -1,8 +1,10 @@
+import json
 import os
 from pathlib import Path
 from unittest import TestCase
 
 import validator.validator as validator
+from validator.versionfile import VersionFile
 from .test_utils import schema, build_map
 
 
@@ -18,8 +20,11 @@ class TestSingleFiles(TestCase):
         os.chdir(cls.old_cwd)
 
     def test_invalidRemote(self):
-        (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
-        self.assertIn(Path('invalid-remote.version'), failed)
+        f = Path('./invalid-remote.version')
+        with f.open('r') as vf:
+            version_file = VersionFile(vf.read())
+            with self.assertRaises(json.decoder.JSONDecodeError):
+                remote = version_file.get_remote()
 
     def test_validRemote(self):
         (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -31,7 +31,8 @@ def validate_cwd(exclude, schema=None, build_map=None):
     failed_files = set()
     ignored_files = found_files.intersection(all_exclusions)
 
-    log.info(f'Ignoring {[str(f) for f in ignored_files]}')
+    if ignored_files:
+        log.info(f'Ignoring {[str(f) for f in ignored_files]}')
 
     if not version_files:
         log.warning('No version files found.')
@@ -137,21 +138,18 @@ def check_single_file(f: Path, schema, latest_ksp):
                     pass
 
         except requests.exceptions.RequestException:
-            log.error(f'Failed downloading remote version file at {version_file.url}. '
+            log.warning(f'Failed downloading remote version file at {version_file.url}. '
                       'Note that the URL property, when used, '
                       'must point to the "Location of a remote version file for update checking"')
-            return False
         except json.decoder.JSONDecodeError as e:
-            log.error(f'Failed loading remote version file at {version_file.url}. '
+            log.warning(f'Failed loading remote version file at {version_file.url}. '
                       f'Note that the URL property, when used, '
                       f'must point to the "Location of a remote version file for update checking". '
                       f'Check for a syntax error around the mentioned line: {e}')
-            return False
         except jsonschema.ValidationError as e:
-            log.error(f'Validation failed for remote version file at {version_file.url}. '
+            log.warning(f'Validation failed for remote version file at {version_file.url}. '
                       f'Note that the URL property, when used, '
                       f'must point to the "Location of a remote version file for update checking": {e}')
-            return False
 
     except json.decoder.JSONDecodeError as e:
         log.error(f'Failed loading {f} as JSON. Check for syntax errors around the mentioned line: {e}')


### PR DESCRIPTION
## Motivation
I reconsidered the handling of remote files.
While they technically have to be valid according to the spec/schema from AVC,
it does not really make sense to fail the whole validation when there's an error.

There are a lot of cases where this is unwanted:
* Creating a new version file, where the remote file isn't uploaded yet
    (likely because the file you are creating is actually the one that will be uploaded/pushed later)
* Fixing a broken (remote) version file:
    you are in the process of fixing the problem, and you want to know whether your fixes actually work.
    Failing the PR validation due to an error you have probably fixed right now is not practical.
* So basically all cases where the remote file and the "local" file are the same.

Only for cases where the remote version file is a separate file, maybe hosted elsewhere,
it makes sense to fail hard. But these are probably the minority.

## Changes
Reduce the impact of invalid remote version files from an error to a warning.

There will be an option added in the future to make the validation fail hard in case of invalid remote files, for those users where it makes sense.

Closes #10