### PR TITLE
Allow specifying list of files to validate in console

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ jobs:
         with:
           fetch-depth: 1
       - name: Validate files
-        uses: DasSkelett/AVC-VersionFileValidator@v1
+        uses: DasSkelett/AVC-VersionFileValidator
 ```
 Make sure workflows are activated in your repository settings:
 ![workflow settings](https://user-images.githubusercontent.com/28812678/73135906-291fe300-4048-11ea-992a-3a0a3800c730.png)
@@ -45,18 +45,22 @@ You can also use globbing statements, for the syntax see syntax, see the [pathli
 
 **For more workflow file examples, see the [examples folder](https://github.com/DasSkelett/AVC-VersionFileValidator/tree/master/examples).**
 
-### Use the package outside of a GitHub action, like Travis
+### Outside of a GitHub action, like locally or in Travis
 You need Python 3.8 installed! Setup:
 ```sh
 git clone https://github.com/DasSkelett/AVC-VersionFileValidator.git
 cd AVC-VersionFileValidator
 python3.8 -m venv venv
 source venv/bin/activate
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt
 ```
-Now use the validator. It is important that your current working directory is the directory where the version files you want to test are located! 
-Also make sure you have the venv activated!
+Now use the validator. Make sure you have the venv activated!
+```sh
+python main.py ../<YourMod>/GameData/<YourMod>/<YourMod>.version
 ```
+Alternatively, if there are more version files to be checked, switch your working directory to the root of your repo and execute main.py from there.
+It will search for version files recursively.
+```sh
 cd ../<YourMod>
 python ../AVC-VersionFileValidator/main.py
 ```

--- a/examples/exclusions.yml
+++ b/examples/exclusions.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Validate files
         with:
           exclude: '["./invalid.version", "./test/corruptVersionFiles/**/*.version"]'
-        uses: DasSkelett/AVC-VersionFileValidator@v1
+        uses: DasSkelett/AVC-VersionFileValidator

--- a/examples/standard.yml
+++ b/examples/standard.yml
@@ -16,4 +16,4 @@ jobs:
         with:
           fetch-depth: 1
       - name: Validate files
-        uses: DasSkelett/AVC-VersionFileValidator@v1
+        uses: DasSkelett/AVC-VersionFileValidator

--- a/main.py
+++ b/main.py
@@ -1,10 +1,11 @@
 #!/usr/bin/env python3.8
 
 import os
+import sys
 from distutils.util import strtobool
 
 from validator.utils import setup_logger
-from validator.validator import validate_cwd
+from validator.validator import validate_cwd, validate_list
 
 
 def validate_current_repository():
@@ -18,5 +19,20 @@ def validate_current_repository():
     exit(status)
 
 
+def validate_list_of_files(file_list):
+    debug = bool(strtobool(os.getenv('INPUT_DEBUG', 'false')))
+    setup_logger(debug)
+
+    (status, successful, failed, ignored) = validate_list(file_list)
+
+    print(f'Exiting with status {status}: {len(successful)} successful, {len(failed)} failed, {len(ignored)} ignored.')
+    exit(status)
+
+
 if __name__ == "__main__":
+    if len(sys.argv) > 1:
+        # Assume the provided arguments is a list of files to check.
+        file_list = sys.argv[1:]
+        validate_list_of_files(file_list)
+
     validate_current_repository()


### PR DESCRIPTION
## Changes
Any arguments given when invoking main.py are now treated as a list of files to be validated exclusively.

Example:
```sh
cd AVC-VersionFileValidator
source ./venv/bin/activate
python main.py ../SomeMod/GameData/SomeMod/SomeMod.version
```

For this there's a new `validator.validate_list()` which takes a list of file path strings.
`validator.validate_list()` and `validator.validate_cwd()` do call `validator.check_file_set()`, which is basically a big part of what `validator.validate_cwd()` did before.
`validator.validate_cwd()` is reduced to calculate the actual set of files to check, based from what can be found in the cwd minus the exclusions.