### PR TITLE
Check version range for possible simplification

### DIFF
--- a/validator/ksp_version.py
+++ b/validator/ksp_version.py
@@ -28,6 +28,7 @@ class KspVersion:
                 self.build = int(m) if (m := match.group('build')) is not None else None
 
         elif isinstance(version, dict):
+            self.any = False
             self.major = int(version.get('MAJOR'))
             self.minor = int(version.get('MINOR'))
             self.patch = int(m) if (m := version.get('PATCH')) is not None else None
@@ -58,6 +59,19 @@ class KspVersion:
         if ksp_version:
             return self == ksp_version
         return False
+
+    def fully_equals(self, other):
+        if self.any != other.any:
+            return False
+        if self.major != other.major:
+            return False
+        if self.minor != other.minor:
+            return False
+        if self.patch != other.patch:
+            return False
+        if self.build != other.build:
+            return False
+        return True
 
     def __eq__(self, other):
         return not self > other and not other > self


### PR DESCRIPTION
## Motivation
Modders often set compatibilities like
```json
"KSP_VERSION_MIN": "1.9.0"
"KSP_VERSION_MIN": "1.9.9"
```
which can and should be simplified to 
```json
"KSP_VERSION": "1.9"
```
or
```json
"KSP_VERSION_MIN": "1.8.0"
"KSP_VERSION_MIN": "1.9.9"
```
which can and should be simplified to 
```json
"KSP_VERSION_MIN": "1.8"
"KSP_VERSION_MIN": "1.9"
```

Sometimes they even set the same version (including patch as min/max, which should also be a single `"KSP_VERSION"`.

## Changes
Introduce additional checks testing for the above, and logging a message on WARNING level suggesting the improvement.

This is only done for the local version file currently, not the remote file.
I'm not yet entirely sure if, and if yes, how it should be done for remote files.