### PR TITLE
Fix TypeError when formatting logging messages that don't have any args

### DIFF
--- a/validator/utils.py
+++ b/validator/utils.py
@@ -48,7 +48,14 @@ class LogFormatter(logging.Formatter):
         # If the log statements contains legacy formatted strings with %s / %d ...
         # logging.Formatter.format() apparently tries to handle it, but doesn't somehow.
         # Only encountered with requests.
-        result = result % record.args
+        # Update 2020-05-21, Python 3.8.2, requests 2.23.0:
+        # For some reason, this has changed now, and requests.exceptions are handled fine.
+        # Instead, this line itself throws the following exception, even for exceptions of other packages:
+        #     TypeError: not enough arguments for format string
+        # Since I think there's the possibility that other error messages would still need the following extra step,
+        # I'm going to keep the line for now, but put it behind an if-clause, which seems to work.
+        if record.args:
+            result = result % record.args
 
         # Restore the original format configured by the user
         self._style._fmt = format_orig


### PR DESCRIPTION
## Problem
For an unknown reason, the `logger.format()` override method throws the following error now:
```
TypeError: not enough arguments for format string
```
Don't know what's going on there, the Python Git(Hub) history doesn't indicate any relevant change with the logging code: https://github.com/python/cpython/commits/master/Lib/logging/__init__.py

## Changes
Hide `result = result % record.args` behind `if record.args:`.
Maybe I could even remove the whole line, but I'm not sure. I'll keep it for now and the above change seems to work.