### PR TITLE
Add 'only' parameter to Action

### DIFF
--- a/.github/workflows/integrationtest-master.yml
+++ b/.github/workflows/integrationtest-master.yml
@@ -1,0 +1,18 @@
+name: Full Integration Test (Docker)
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  full_integration_docker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Validate files
+        with:
+          only: '["./tests/workspaces/valid-remote.version"]'
+        uses: DasSkelett/AVC-VersionFileValidator@master

--- a/.github/workflows/integrationtest.yml
+++ b/.github/workflows/integrationtest.yml
@@ -1,14 +1,14 @@
 name: Full Integration Test
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   full_integration_run:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -24,5 +24,5 @@ jobs:
         python -m unittest tests
     - name: Run unit tests in Docker container
       run: |
-        docker build --target tests -t avc-versionfilevalidator .
+        docker build -f Dockerfile-dev --target tests -t avc-versionfilevalidator .
         docker run avc-versionfilevalidator

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -1,14 +1,14 @@
 name: Unit Tests
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 
 jobs:
   run_unit_tests:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.8

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
+temp/
+
 /venv/
 __pycache__/

--- a/.idea/jsonSchemas.xml
+++ b/.idea/jsonSchemas.xml
@@ -30,6 +30,29 @@
             </SchemaInfo>
           </value>
         </entry>
+        <entry key="github-workflow">
+          <value>
+            <SchemaInfo>
+              <option name="name" value="github-workflow" />
+              <option name="relativePathToSchema" value="http://json.schemastore.org/github-workflow" />
+              <option name="applicationDefined" value="true" />
+              <option name="patterns">
+                <list>
+                  <Item>
+                    <option name="directory" value="true" />
+                    <option name="path" value=".github/workflows" />
+                    <option name="mappingKind" value="Directory" />
+                  </Item>
+                  <Item>
+                    <option name="directory" value="true" />
+                    <option name="path" value="examples" />
+                    <option name="mappingKind" value="Directory" />
+                  </Item>
+                </list>
+              </option>
+            </SchemaInfo>
+          </value>
+        </entry>
       </map>
     </state>
   </component>

--- a/.idea/pylint.xml
+++ b/.idea/pylint.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="PylintConfigService">
+    <option name="scanBeforeCheckin" value="false" />
+  </component>
+</project>

--- a/.idea/runConfigurations/Tests__Docker_.xml
+++ b/.idea/runConfigurations/Tests__Docker_.xml
@@ -2,13 +2,13 @@
   <configuration default="false" name="Tests (Docker)" type="docker-deploy" factoryName="dockerfile" server-name="Docker">
     <deployment type="dockerfile">
       <settings>
+        <option name="imageTag" value="" />
         <option name="buildCliOptions" value="--target tests" />
         <option name="command" value="" />
         <option name="containerName" value="" />
         <option name="entrypoint" value="" />
-        <option name="imageTag" value="" />
         <option name="commandLineOptions" value="" />
-        <option name="sourceFilePath" value="Dockerfile" />
+        <option name="sourceFilePath" value="Dockerfile-dev" />
       </settings>
     </deployment>
     <method v="2" />

--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -5,6 +5,7 @@ RUN pip3 install -r /requirements.txt
 ENTRYPOINT ["python3.8"]
 
 
-FROM base as prod
-COPY main.py /main.py
-CMD ["/main.py"]
+FROM base as tests
+COPY tests/ /tests/
+WORKDIR /
+CMD ["-m", "unittest", "tests"]

--- a/README.md
+++ b/README.md
@@ -38,14 +38,29 @@ Make sure workflows are activated in your repository settings:
 ![workflow settings](https://user-images.githubusercontent.com/28812678/73135906-291fe300-4048-11ea-992a-3a0a3800c730.png)
 The top radio button should be selected.
 
-To exclude files, add a JSON array containing the paths to the files (relative from repo rooot) as `exclude` parameter after `- name: Validate files`:
+#### Parameters
+Workflow files support passing parameters to the executed Actions using the `with` property,
+The following options are available for the KSP-AVC Version File Validator:
+
+##### Blacklist / Exclusions
+To exclude files, add a JSON array containing the paths to the files (relative from repo root) as `exclude` parameter after `- name: Validate files`:
 ```yaml
         with:
-          exclude: '["./invalid.version", "./test/corruptVersionFiles/**/*.version"]'
+          exclude: '["./GameData/BundledMod/BundledMod.version", "./GameData/OtherBundledMod/**/*.version"]'
 ```
-You can also use globbing statements, for the syntax see syntax, see the [pathlib documentation](https://docs.python.org/3.5/library/pathlib.html#pathlib.PurePath.match).
+You can use globbing statements, for the syntax see the [pathlib documentation](https://docs.python.org/3.5/library/pathlib.html#pathlib.PurePath.match).
 
-**For more workflow file examples, see the [examples folder](https://github.com/DasSkelett/AVC-VersionFileValidator/tree/master/examples).**
+[Example](https://github.com/DasSkelett/AVC-VersionFileValidator/tree/master/examples/exclusions.yml)
+
+##### Whitelist / Inclusions
+If you only want to test a specific set of files, you can use the `only` parameter. Can't be used together with `exclude`!
+```yaml
+        with:
+          only: '["./GameData/YourMod/YourMod.version"]'
+```
+
+[Example](https://github.com/DasSkelett/AVC-VersionFileValidator/tree/master/examples/whitelist.yml)
+
 
 ### Outside of a GitHub action, like locally or in Travis
 You need Python 3.8 installed! Setup:

--- a/README.md
+++ b/README.md
@@ -16,9 +16,11 @@ Then commit and push it to GitHub.
  
 Alternatively, copy the following and put it in `<YourMod>/.github/workflows/AVC-VersionFileValidator.yml`.
 ```yaml
-name: Validate AVC .version files
+name: AVC .version file validation
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/action.yml
+++ b/action.yml
@@ -6,6 +6,10 @@ inputs:
     description: 'JSON-array-like list of paths to version files to exclude (supports wildcards), e.g. ["KSP-AVC.version", "GameData/DogeCoinFlag/*.version"]'
     required: false
     default: ''
+  only:
+    description: 'JSON-array-like list of paths to version files to check exclusively (no wildcard support), e.g. ["GameData/YourMod/YourMod.version"]'
+    required: false
+    default: ''
 runs:
   using: 'docker'
   image: 'Dockerfile'

--- a/examples/exclusions.yml
+++ b/examples/exclusions.yml
@@ -1,9 +1,11 @@
 # This workflow excludes some .version files.
 # It supports globbing according to Python3 pathlib.Path.glob() rules (so also recursive globs with `**`).
 # Make sure the exclusion string is a valid JSON array!
-name: Validate AVC .version files
+name: AVC .version file validation
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/examples/standard.yml
+++ b/examples/standard.yml
@@ -2,9 +2,11 @@
 # found in the root directory of the repository and any subdirectories,
 # whenever something is pushed to any branch in the repository, or to a "foreign" branch active in a pull request.
 # It should cover most cases.
-name: Validate AVC .version files
+name: AVC .version file validation
 on:
   push:
+    branches:
+      - master
   pull_request:
     types: [opened, synchronize, reopened]
 jobs:

--- a/examples/whitelist.yml
+++ b/examples/whitelist.yml
@@ -1,0 +1,21 @@
+# This workflow only validates the files specified in the 'only' parameter.
+# Make sure the exclusion string is a valid JSON array!
+name: AVC .version file validation
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    types: [opened, synchronize, reopened]
+jobs:
+  validate_version_files:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: Validate files
+        with:
+          only: '["./GameData/YourMod.version"]'
+        uses: DasSkelett/AVC-VersionFileValidator

--- a/main.py
+++ b/main.py
@@ -1,11 +1,24 @@
 #!/usr/bin/env python3.8
-
 import os
 import sys
 from distutils.util import strtobool
 
-from validator.utils import setup_logger
+from validator.utils import get_env_array
+from validator.logger import setup_logger
 from validator.validator import validate_cwd, validate_list
+
+
+def main():
+    if len(sys.argv) > 1:
+        # Assume the provided arguments are a list of files to check.
+        argv_whitelist = sys.argv[1:]
+        validate_list_of_files(argv_whitelist)
+    elif env_whitelist := get_env_array('INPUT_ONLY'):
+        # We got a whitelist of files to check via env var
+        validate_list_of_files(env_whitelist)
+    else:
+        # Else go the normal route and check everything in the cwd.
+        validate_current_repository()
 
 
 def validate_current_repository():
@@ -30,9 +43,4 @@ def validate_list_of_files(file_list):
 
 
 if __name__ == "__main__":
-    if len(sys.argv) > 1:
-        # Assume the provided arguments is a list of files to check.
-        file_list = sys.argv[1:]
-        validate_list_of_files(file_list)
-
-    validate_current_repository()
+    main()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,8 +1,9 @@
-from validator.utils import setup_logger
+from validator.logger import setup_logger
 from .default import *
 from .ksp_version import *
 from .singlefiles import *
 from .strangenames import *
+from .utils import *
 from .versionfile import *
 
 # Use logging.getLogger('tests').<lvl>() for logging in the tests.

--- a/tests/ksp_version.py
+++ b/tests/ksp_version.py
@@ -28,6 +28,10 @@ class TestKspVersion(TestCase):
         v = KspVersion.try_parse('xxx.yyy.zzz')
         self.assertIsNone(v)
 
+    def test_parse_invalid(self):
+        with self.assertRaises(TypeError):
+            KspVersion('aaa.bbb.ccc')
+
     def test_comp_different_level(self):
         v1 = KspVersion('1.2.3')
         v2 = KspVersion('1.2')
@@ -74,3 +78,8 @@ class TestKspVersion(TestCase):
         v_ksp = KspVersion('1.8.1')
 
         self.assertTrue(v_latest_ksp.is_contained_in(v_ksp, None, None))
+
+    def test_fully_equals(self):
+        self.assertTrue(KspVersion('1.9.1.2788').fully_equals(KspVersion('1.9.1.2788')))
+        self.assertFalse(KspVersion('1.9.1.2788').fully_equals(KspVersion('1.9.1')))
+        self.assertFalse(KspVersion('1.9.1.2788').fully_equals(KspVersion('1.9.1.9999')))

--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -24,8 +24,14 @@ class TestSingleFiles(TestCase):
         with f.open('r') as vf:
             version_file = VersionFile(vf.read())
             with self.assertRaises(json.decoder.JSONDecodeError):
-                remote = version_file.get_remote()
+                version_file.get_remote()
 
-    def test_validRemote(self):
+    def test_validRemote_cwd(self):
         (status, successful, failed, ignored) = validator.validate_cwd('', schema, build_map)
         self.assertIn(Path('valid-remote.version'), successful)
+
+    def test_validRemote_list(self):
+        (status, successful, failed, ignored) = validator.validate_list(['./valid-remote.version'], schema, build_map)
+        wanted = set()
+        wanted.add(Path('valid-remote.version'))
+        self.assertEquals(wanted, successful)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,10 @@
+import os
+from unittest import TestCase
+
+from validator.utils import get_env_array
+
+
+class TestUtils(TestCase):
+    def test_getEnvArray(self):
+        os.environ['INPUT_ONLY'] = '["fileA.version", "fileB.txt"]'
+        self.assertEquals(get_env_array('INPUT_ONLY'), ['fileA.version', 'fileB.txt'])

--- a/validator/ksp_version.py
+++ b/validator/ksp_version.py
@@ -22,6 +22,8 @@ class KspVersion:
             else:
                 self.any = False
                 match = self.rgx.fullmatch(version)
+                if match is None:
+                    raise TypeError(f'Malformed KSP version: {version}')
                 self.major = int(match.group('major'))
                 self.minor = int(match.group('minor'))
                 self.patch = int(m) if (m := match.group('patch')) is not None else None
@@ -34,9 +36,9 @@ class KspVersion:
             self.patch = int(m) if (m := version.get('PATCH')) is not None else None
             self.build = int(m) if (m := version.get('BUILD')) is not None else None
         else:
-            raise TypeError('The version is neither a well-formatted string nor a dict.')
+            raise TypeError(f'KSP version {version} is neither a well-formatted string nor a dict.')
         if not (self.major and self.minor):
-            raise TypeError('Version needs at least a MAJOR and MINOR.')
+            raise TypeError(f'A KSP version needs at least a MAJOR and MINOR: {version}')
 
     # From AVC code:
     # (Ignoring KSP_INCLUDE_VERSIONS and KSP_EXCLUDE_VERSIONS)

--- a/validator/logger.py
+++ b/validator/logger.py
@@ -1,0 +1,63 @@
+import logging
+import sys
+
+
+def setup_logger(debug, logger_name=''):
+    log = logging.getLogger(logger_name)
+    level = logging.DEBUG if debug else logging.INFO
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(LogFormatter())
+    log.addHandler(handler)
+    log.setLevel(level)
+    log.info(f'Logger {logger_name} started with level {level}')
+
+
+# https://stackoverflow.com/a/14859558
+class LogFormatter(logging.Formatter):
+
+    dbg_fmt = "::DEBUG::%(msg)s"
+    info_fmt = "::INFO::%(msg)s"
+    wrn_fmt = "::WARNING::%(msg)s"
+    err_fmt = "::ERROR::%(msg)s"
+
+    def __init__(self):
+        super().__init__(fmt="%(levelno)d: %(msg)s", datefmt=None, style='%')
+
+    def format(self, record):
+
+        # Save the original format configured by the user
+        # when the logger formatter was instantiated
+        format_orig = self._style._fmt
+
+        # Replace the original format with one customized by logging level
+        if record.levelno == logging.DEBUG:
+            self._style._fmt = LogFormatter.dbg_fmt
+
+        elif record.levelno == logging.INFO:
+            self._style._fmt = LogFormatter.info_fmt
+
+        elif record.levelno == logging.WARNING:
+            self._style._fmt = LogFormatter.wrn_fmt
+
+        elif record.levelno == logging.ERROR:
+            self._style._fmt = LogFormatter.err_fmt
+
+        # Call the original formatter class to do the grunt work
+        result = logging.Formatter.format(self, record)
+
+        # If the log statements contains legacy formatted strings with %s / %d ...
+        # logging.Formatter.format() apparently tries to handle it, but doesn't somehow.
+        # Only encountered with requests.
+        # Update 2020-05-21, Python 3.8.2, requests 2.23.0:
+        # For some reason, this has changed now, and requests.exceptions are handled fine.
+        # Instead, this line itself throws the following exception, even for exceptions of other packages:
+        #     TypeError: not enough arguments for format string
+        # Since I think there's the possibility that other error messages would still need the following extra step,
+        # I'm going to keep the line for now, but put it behind an if-clause, which seems to work.
+        if record.args:
+            result = result % record.args
+
+        # Restore the original format configured by the user
+        self._style._fmt = format_orig
+
+        return result

--- a/validator/utils.py
+++ b/validator/utils.py
@@ -1,63 +1,22 @@
-import logging
-import sys
+import json
+import os
+from typing import List
 
 
-def setup_logger(debug, logger_name=''):
-    log = logging.getLogger(logger_name)
-    level = logging.DEBUG if debug else logging.INFO
-    handler = logging.StreamHandler(sys.stdout)
-    handler.setFormatter(LogFormatter())
-    log.addHandler(handler)
-    log.setLevel(level)
-    log.info(f'Logger {logger_name} started with level {level}')
+def get_env_array(env_name: str):
+    env_str = os.getenv(env_name, '')
+    if env_str and not env_str.isspace():
+        return parse_json_array(env_str)
 
 
-# https://stackoverflow.com/a/14859558
-class LogFormatter(logging.Formatter):
-
-    dbg_fmt = "::DEBUG::%(msg)s"
-    info_fmt = "::INFO::%(msg)s"
-    wrn_fmt = "::WARNING::%(msg)s"
-    err_fmt = "::ERROR::%(msg)s"
-
-    def __init__(self):
-        super().__init__(fmt="%(levelno)d: %(msg)s", datefmt=None, style='%')
-
-    def format(self, record):
-
-        # Save the original format configured by the user
-        # when the logger formatter was instantiated
-        format_orig = self._style._fmt
-
-        # Replace the original format with one customized by logging level
-        if record.levelno == logging.DEBUG:
-            self._style._fmt = LogFormatter.dbg_fmt
-
-        elif record.levelno == logging.INFO:
-            self._style._fmt = LogFormatter.info_fmt
-
-        elif record.levelno == logging.WARNING:
-            self._style._fmt = LogFormatter.wrn_fmt
-
-        elif record.levelno == logging.ERROR:
-            self._style._fmt = LogFormatter.err_fmt
-
-        # Call the original formatter class to do the grunt work
-        result = logging.Formatter.format(self, record)
-
-        # If the log statements contains legacy formatted strings with %s / %d ...
-        # logging.Formatter.format() apparently tries to handle it, but doesn't somehow.
-        # Only encountered with requests.
-        # Update 2020-05-21, Python 3.8.2, requests 2.23.0:
-        # For some reason, this has changed now, and requests.exceptions are handled fine.
-        # Instead, this line itself throws the following exception, even for exceptions of other packages:
-        #     TypeError: not enough arguments for format string
-        # Since I think there's the possibility that other error messages would still need the following extra step,
-        # I'm going to keep the line for now, but put it behind an if-clause, which seems to work.
-        if record.args:
-            result = result % record.args
-
-        # Restore the original format configured by the user
-        self._style._fmt = format_orig
-
-        return result
+def parse_json_array(json_string: str) -> List:
+    try:
+        array = json.loads(json_string)
+        # If someone passes a string like this: '"./*.version"'
+        if isinstance(array, str):
+            return [array]
+        else:
+            return array
+    except json.decoder.JSONDecodeError:
+        # Not a valid JSON array, assume it is a single file
+        return [json_string]

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -6,6 +6,7 @@ from typing import Set
 import jsonschema
 import requests
 
+from .utils import parse_json_array
 from .ksp_version import KspVersion
 from .versionfile import VersionFile
 
@@ -111,15 +112,7 @@ def check_file_set(version_files, schema=None, build_map=None):
 def calculate_all_exclusions(exclude: str) -> Set[Path]:
     all_exclusions = set()
     if exclude and not exclude.isspace():
-        try:
-            globs = json.loads(exclude)
-        except json.decoder.JSONDecodeError:
-            # Not a valid JSON array, assume it is a single exclusion glob
-            globs = [exclude]
-
-        # If someone passes a string like this: '"./*.version"'
-        if isinstance(globs, str):
-            globs = [globs]
+        globs = parse_json_array(exclude)
 
         for _glob in globs:
             all_exclusions = all_exclusions.union(Path().glob(_glob))


### PR DESCRIPTION
## Motivation
Since #13 there's an option to validate only a specified list of files by giving command line arguments to `main.py`.
Now it's time to also give Action users this possibility.

## Changes
1) Added a new `only` parameter to the Action. If specified using `with` in a workflow, AVC-VersionFileValidator will only check these files.
Does not support globbing currently, it is also mutually exclusive with `exclude`.
2) I updated my own workflows and the example workflows to only trigger on pushes to _master_ (+ PR events), instead of pushes to _all branches_ (+ PR events). This has lead to workflow checks being executed twice for commits on a branch in the main repo that are also part of a PR.
3) Moved the logging code into `validator/logger.py`, in `validator/utils.py` are now some new utility functions.
4) Added some more tests, mainly for the KSP version comparison logic.
5) Split the Dockerfile, so that production usage doesn't run the unit tests. GitHub unfortunately doesn't allow specifying stages for actions.
6) Added a new integration test workflow, which uses this Action itself. Can only run on master.