### PR TITLE
Annotate warnings and erros in PR Changes overview

### DIFF
--- a/tests/singlefiles.py
+++ b/tests/singlefiles.py
@@ -22,7 +22,7 @@ class TestSingleFiles(TestCase):
     def test_invalidRemote(self):
         f = Path('./invalid-remote.version')
         with f.open('r') as vf:
-            version_file = VersionFile(vf.read())
+            version_file = VersionFile(vf.read(), f)
             with self.assertRaises(json.decoder.JSONDecodeError):
                 version_file.get_remote()
 

--- a/validator/validator.py
+++ b/validator/validator.py
@@ -6,8 +6,9 @@ from typing import Set
 import jsonschema
 import requests
 
-from .utils import parse_json_array
 from .ksp_version import KspVersion
+from .logger import LogExtra
+from .utils import parse_json_array
 from .versionfile import VersionFile
 
 
@@ -20,7 +21,7 @@ def validate_cwd(exclude, schema=None, build_map=None):
     :return: A 4-tuple containing the validation status, valid files, failed files and ignored files.
     :rtype: (int, Set[Path], Set[Path], Set[Path])
     """
-    all_exclusions = calculate_all_exclusions(exclude)
+    all_exclusions = _calculate_all_exclusions(exclude)
 
     # GH will set the cwd of the container to the so-called workspace, which is a clone of the triggering repo,
     # assuming the user remembered to add the 'actions/checkout' step before.
@@ -33,7 +34,7 @@ def validate_cwd(exclude, schema=None, build_map=None):
     if ignored_files:
         log.info(f'Ignoring {[str(f) for f in ignored_files]}')
 
-    (code, successful_files, failed_files) = check_file_set(version_files, schema, build_map)
+    (code, successful_files, failed_files) = _check_file_set(version_files, schema, build_map)
     return code, successful_files, failed_files, ignored_files
 
 
@@ -58,12 +59,12 @@ def validate_list(file_list, schema=None, build_map=None):
     if nonexistent_files:
         log.info(f'Files {[str(f) for f in nonexistent_files]} don\'t exist')
 
-    (code, successful_files, failed_files) = check_file_set(version_files, schema, build_map)
+    (code, successful_files, failed_files) = _check_file_set(version_files, schema, build_map)
     return code, successful_files, failed_files, nonexistent_files
 
 
-def check_file_set(version_files, schema=None, build_map=None):
-    """Validates the given set of files.
+def _check_file_set(version_files, schema=None, build_map=None):
+    """Validates the given set of files. For internal use only.
 
     :param version_files: A set of Path-es to validate.
     :param schema: A **valid** Python object representing the schema. Use sparingly, intended for tests!
@@ -109,7 +110,7 @@ def check_file_set(version_files, schema=None, build_map=None):
         return 0, successful_files, failed_files
 
 
-def calculate_all_exclusions(exclude: str) -> Set[Path]:
+def _calculate_all_exclusions(exclude: str) -> Set[Path]:
     all_exclusions = set()
     if exclude and not exclude.isspace():
         globs = parse_json_array(exclude)
@@ -143,37 +144,39 @@ def get_build_map():
 
 # Returns a bool to indicate whether the file and its remote is valid or not.
 def check_single_file(f: Path, schema, latest_ksp):
+    log.info(f'Checking {f}')
+    log_extra = LogExtra(f)
     try:
-        log.info(f'Checking {f}')
         with f.open('r') as vf:
             log.debug(f'Loading {f}')
-            version_file = VersionFile(vf.read())
+            version_file = VersionFile(vf.read(), f)
 
         log.debug(f'Validating {f}')
         version_file.validate(schema, False)
         if latest_ksp is not None and not version_file.is_compatible_with_ksp(latest_ksp):
             log.warning(f"The file {f} doesn't indicate compatibility "
                         f"with the latest version of KSP ({str(latest_ksp)}). "
-                        f"Did you forget to update it?")
+                        f"Did you forget to update it?", extra=log_extra.asdict())
 
         vmin = version_file.ksp_version_min
         vmax = version_file.ksp_version_max
         if vmin is not None and vmax is not None:
             if vmin.fully_equals(vmax):
                 log.warning(f'KSP_VERSION_MIN and KSP_VERSION_MAX are the same. '
-                            f'Consider using KSP_VERSION instead.')
+                            f'Consider using KSP_VERSION instead.', extra=log_extra.asdict())
 
             elif vmin.patch == 0 and str(vmax.patch).startswith('9'):
                 if vmin.major == vmax.major and vmin.minor == vmax.minor:
                     target_version = KspVersion({"MAJOR": vmin.major, "MINOR": vmin.minor})
                     log.warning(f'The KSP version range indicates compatibility with a full minor range. '
-                                f'Consider removing KSP_VERSION_MIN/MAX and adding KSP_VERSION {target_version} instead.')
+                                f'Consider removing KSP_VERSION_MIN/MAX and adding KSP_VERSION {target_version} '
+                                f'instead.', extra=log_extra.asdict())
                 else:
                     target_version_min = KspVersion({"MAJOR": vmin.major, "MINOR": vmin.minor})
                     target_version_max = KspVersion({"MAJOR": vmax.major, "MINOR": vmax.minor})
                     log.warning(f'The KSP version range indicates compatibility across full minor ranges. '
                                 f'Consider changing KSP_VERSION_MIN to {target_version_min} and '
-                                f'KSP_VERSION_MAX to {target_version_max}.')
+                                f'KSP_VERSION_MAX to {target_version_max}.', extra=log_extra.asdict())
 
         # Check remote version file
         try:
@@ -184,30 +187,37 @@ def check_single_file(f: Path, schema, latest_ksp):
                     if latest_ksp is not None and not remote.is_compatible_with_ksp(latest_ksp):
                         log.warning(f"The remote version file of {f} doesn't indicate compatibility "
                                     f"with the latest version of KSP ({str(latest_ksp)}). "
-                                    f"Did you forget to update it? {version_file.url}")
+                                    f"Did you forget to update it? {version_file.url}", extra=log_extra.asdict())
                 except:
                     pass
 
         except requests.exceptions.RequestException:
             log.warning(f'Failed downloading remote version file at {version_file.url}. '
                         f'Note that the URL property, when used, '
-                        f'must point to the "Location of a remote version file for update checking"')
+                        f'must point to the "Location of a remote version file for update checking"',
+                        extra=log_extra.asdict())
         except json.decoder.JSONDecodeError as e:
+            log_extra.line = e.lineno
+            log_extra.col = e.colno
             log.warning(f'Failed loading remote version file at {version_file.url}. '
                         f'Note that the URL property, when used, '
                         f'must point to the "Location of a remote version file for update checking". '
-                        f'Check for a syntax error around the mentioned line: {e}')
+                        f'Check for a syntax error around the mentioned line: {e}', extra=log_extra.asdict())
         except jsonschema.ValidationError as e:
             log.warning(f'Validation failed for remote version file at {version_file.url}. '
                         f'Note that the URL property, when used, '
-                        f'must point to the "Location of a remote version file for update checking": {e}')
+                        f'must point to the "Location of a remote version file for update checking": {e}',
+                        extra=log_extra.asdict())
 
     except json.decoder.JSONDecodeError as e:
-        log.error(f'Failed loading {f} as JSON. Check for syntax errors around the mentioned line: {e}')
+        log_extra.line = e.lineno
+        log_extra.col = e.colno
+        log.error(f'Failed loading {f} as JSON. Check for syntax errors around the mentioned line: {e}',
+                  extra=log_extra.asdict())
         return False
 
     except jsonschema.ValidationError as e:
-        log.error(f'Validation of {f} failed: {e}')
+        log.error(f'Validation of {f} failed: {e}', log_extra.asdict(), extra=log_extra.asdict())
         return False
 
     log.debug(f'Validation of {f} successful.')

--- a/validator/versionfile.py
+++ b/validator/versionfile.py
@@ -1,6 +1,7 @@
 import json
 import logging as log
 import re
+from pathlib import Path
 
 import jsonschema
 import requests
@@ -10,7 +11,7 @@ from .ksp_version import KspVersion
 
 class VersionFile:
 
-    def __init__(self, content: str):
+    def __init__(self, content: str, path: Path):
 
         self.json = json.loads(content)
         self.raw = content
@@ -46,6 +47,7 @@ class VersionFile:
 
         self._remote = None
         self.valid = False
+        self.path = path
 
     def get_remote(self):
         if self._remote:
@@ -53,7 +55,8 @@ class VersionFile:
         if not self.url:
             return None
         log.debug('Fetching remote...')
-        self._remote = VersionFile(requests.get(get_raw_uri(self.url)).text)
+        # Give the remote version file the path of the local one so the logger puts the annotations in the right place.
+        self._remote = VersionFile(requests.get(get_raw_uri(self.url)).text, self.path)
         return self._remote
 
     # Validates this and optional a remote version file. Throws all exception it encounters.


### PR DESCRIPTION
## Motivation
As of now you can only find out about potential warnings for a version file when checking the output log of the workflow.
Most people probably won't do that if it succeeds.

## Changes
To increase the visibility of warnings, the validator now annotates warnings to the line they belong to if possible, or to line 1 if we don't have a specific line. Same applies for errors.
This looks like this:
![image](https://user-images.githubusercontent.com/28812678/87353312-ccb07180-c55c-11ea-8898-e3a400c485b1.png)
![image](https://user-images.githubusercontent.com/28812678/87353352-e0f46e80-c55c-11ea-8932-c72e4912942b.png)


Furthermore I moved the exception handling for the loading and validation of the local version file further up, so the try-except only covers the area we actually want to cover.
Should make it also easier to find out witch `except:` belongs to which code lines.